### PR TITLE
Remove unneeded conditions from finalize tasks

### DIFF
--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -2,10 +2,8 @@
   shell: "{{item}}"
   become: yes
   with_items: "{{deploy.finalize.commands}}"
-  when: deploy.finalize.required_sudo == True
 
 - name: restarting services
   service: name="{{item}}" state=restarted
   become: yes
   with_items: "{{deploy.finalize.to_be_restarted_services}}"
-  when: deploy.finalize.required_sudo == True


### PR DESCRIPTION
Removed some old conditions from finalize tasks which prevented commands and services restart from running if sudo not used